### PR TITLE
Fix scheduler sync job serialization

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ from shared.cache import init_cache
 from shared.logger import logger, init_logging
 from .models import db, SyncEvent
 from . import scheduler
-from .scheduler import sched, process_unsent_events
+from .scheduler import sched, enqueue_sync_job
 from .routes import api_bp, auth_bp
 from app.routes import register_web
 
@@ -88,7 +88,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
                 fb = Path(app.config["SYNC_FALLBACK_FILE"])
                 if fb.exists():
                     fb.unlink()
-                scheduler.queue.enqueue(process_unsent_events, socketio)
+                scheduler.queue.enqueue(enqueue_sync_job)
                 if not getattr(app, "redis_online", True):
                     logger.info("Redis connection restored")
                     socketio.emit("redis_status", {"online": True})

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -196,3 +196,10 @@ def process_unsent_events(socketio: SocketIO) -> None:
             )
             evt.synced = True
         db.session.commit()
+
+
+def enqueue_sync_job() -> None:
+    """Entry point for the RQ worker to process unsent events."""
+    from backend import socketio as _socketio
+
+    process_unsent_events(_socketio)


### PR DESCRIPTION
## Summary
- avoid lambdas for RQ jobs
- add `enqueue_sync_job` entry point
- queue sync job without passing SocketIO object

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a91ed5408321950f370851b9b34a