### PR TITLE
Fix CSP headers and API responses

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -103,7 +103,7 @@ async function loadGroups() {
   const url = q.length > 1 ? '/dashboard/api/groups?search=' + encodeURIComponent(q) : '/dashboard/api/groups';
   const data = await api(url);
   if (!data) return;
-  const groups = data.items || data;
+  const groups = data.items || [];
   const list = document.getElementById('groupList');
   list.innerHTML = '';
   if (!groups.length) {
@@ -133,7 +133,7 @@ async function loadAccounts() {
   const url = q.length > 1 ? '/dashboard/api/accounts?search=' + encodeURIComponent(q) : '/dashboard/api/accounts';
   const data = await api(url);
   if (!data) return;
-  const accs = data.items || data;
+  const accs = data.items || [];
   const table = document.getElementById('accountTable');
   table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group</th></tr>';
   if (!accs.length) {
@@ -154,7 +154,7 @@ async function loadBots() {
   const url = q.length > 1 ? '/dashboard/api/bots?search=' + encodeURIComponent(q) : '/dashboard/api/bots';
   const data = await api(url);
   if (!data) return;
-  const bots = data.items || data;
+  const bots = data.items || [];
   const table = document.getElementById('botTable');
   table.innerHTML = '<tr><th>ID</th><th>User</th><th>Status</th><th>Actions</th></tr>';
   if (!bots.length) {

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -121,6 +121,16 @@ def create_app(config: Optional[dict] = None) -> Flask:
         except Exception:
             pass
 
+    @app.after_request
+    def add_csp(response):
+        csp = (
+            "default-src 'self'; object-src 'none'; "
+            "script-src 'self' https://cdn.jsdelivr.net https://cdn.socket.io; "
+            "style-src 'self' https://cdn.jsdelivr.net;"
+        )
+        response.headers["Content-Security-Policy"] = csp
+        return response
+
     register_web(app)
     api.init_app(app)
     app.register_blueprint(api_bp)

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -83,7 +83,7 @@ class GroupResource(Resource):
         if not search and page == 1 and per_page == 50:
             cached = cache.get("groups")
             if cached is not None:
-                return cached
+                return cached, 200
         query = Group.query
         if search:
             query = query.filter(Group.name.ilike(f"%{search}%"))
@@ -101,7 +101,7 @@ class GroupResource(Resource):
         result = {"items": groups, "total": pagination.total}
         if not search and page == 1 and per_page == 50:
             cache.set("groups", result, timeout=60)
-        return result
+        return result, 200
 
     @role_required("operator", "admin")
     def post(self):
@@ -151,7 +151,7 @@ class AccountResource(Resource):
             {"id": a.id, "username": a.username, "group_id": a.group_id}
             for a in pagination.items
         ]
-        return {"items": accounts, "total": pagination.total}
+        return {"items": accounts, "total": pagination.total}, 200
 
     @role_required("operator", "admin")
     def post(self):
@@ -216,7 +216,7 @@ class BotListResource(Resource):
                     "status": status,
                 }
             )
-        return {"items": bots, "total": pagination.total}
+        return {"items": bots, "total": pagination.total}, 200
 
     @role_required("operator", "admin")
     def post(self):


### PR DESCRIPTION
## Summary
- add an `after_request` handler to set Content Security Policy allowing cdn.jsdelivr.net and cdn.socket.io
- ensure API list endpoints always return `{items, total}` with HTTP 200
- guard against missing `items` field in dashboard JS

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882acac06d8832196daa12f97372c9a