### PR TITLE
Fix tokenless access to API

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -49,10 +49,14 @@ async function refreshToken() {
 }
 
 async function api(url, opts = {}) {
-  opts.headers = Object.assign({}, opts.headers, {
-    'X-CSRFToken': csrfToken,
-    'Authorization': 'Bearer ' + getAccess()
+  const token = getAccess();
+  const headers = Object.assign({}, opts.headers, {
+    'X-CSRFToken': csrfToken
   });
+  if (token) {
+    headers['Authorization'] = 'Bearer ' + token;
+  }
+  opts.headers = headers;
   showSpinner();
   let res = await fetch(url, opts).catch(() => null);
   if (res && res.status === 401) {


### PR DESCRIPTION
## Summary
- don't send invalid `Authorization` header when no access token is set

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6882c73f8e28832194fbe17133ff838c