### PR TITLE
Add deletion features for groups and bots

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -76,6 +76,27 @@ function openCmd(id) {
   document.getElementById('cmdDialog').showModal();
 }
 
+async function deleteGroup(id) {
+  const res = await api(`/dashboard/api/groups/${id}`, { method: 'DELETE' });
+  if (res && res.deleted) {
+    showToast('Group deleted');
+    loadGroups();
+    loadAccounts();
+    loadBots();
+    syncPush();
+  }
+}
+
+async function deleteBot(id) {
+  const res = await api(`/dashboard/api/bots/${id}`, { method: 'DELETE' });
+  if (res && res.deleted) {
+    showToast('Bot deleted');
+    loadAccounts();
+    loadBots();
+    syncPush();
+  }
+}
+
 async function syncPull() {
   const res = await api('/sync/pull');
   if (!res) return;
@@ -113,7 +134,7 @@ async function loadGroups() {
   groups.forEach(g => {
     const li = document.createElement('li');
     li.className = 'mb-1';
-    li.innerHTML = `<div class="font-semibold">${g.name} (${g.target})</div>`;
+    li.innerHTML = `<div class="flex justify-between"><span class="font-semibold">${g.name} (${g.target})</span><button onclick="deleteGroup(${g.id})" class="text-red-600 text-xs">Delete</button></div>`;
     if (g.bots && g.bots.length) {
       const ul = document.createElement('ul');
       ul.className = 'pl-4 list-disc';
@@ -177,6 +198,7 @@ async function loadBots() {
         `<button onclick="stopBot(${b.id})" class="bg-red-600 text-white px-2 py-1 text-xs rounded">Stop</button>` +
         `<button onclick="openCmd(${b.id})" class="bg-blue-500 text-white px-2 py-1 text-xs rounded">Cmd</button>` +
         `<button onclick="fetchLogs(${b.id})" class="underline text-xs">Logs</button>` +
+        `<button onclick="deleteBot(${b.id})" class="text-red-600 underline text-xs">Delete</button>` +
       `</td>`;
     table.appendChild(row);
   });

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -63,7 +63,12 @@ async function api(url, opts = {}) {
     }
   }
   hideSpinner();
-  if (!res) return null;
+  if (!res || !res.ok) {
+    if (res && res.status === 401) {
+      showToast('Please log in', false);
+    }
+    return null;
+  }
   return res.json();
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,12 @@
 
 This site describes API endpoints and usage of the KickBot system.
 
+## Features
+
+- Manage groups and bot accounts
+- Start or stop bots on demand
+- **New:** delete groups or bots from the dashboard
+
 ## Running locally
 
 ```bash

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,8 @@
-import pytest
 import bcrypt
+import pytest
 
 from backend import create_app
-from backend.models import db
+from backend.models import Account, Group, db
 
 
 @pytest.fixture
@@ -109,3 +109,21 @@ def test_bot_start_stop(client, tmp_path):
 
     res = client.post(f"/dashboard/api/bots/{aid}/stop")
     assert res.status_code == 200
+
+
+def test_delete_group_and_bot(client):
+    gid = client.post(
+        "/dashboard/api/groups", json={"name": "delg", "target": "t"}
+    ).get_json()["id"]
+    aid = client.post(
+        "/dashboard/api/accounts",
+        json={"username": "del", "password": "p", "group_id": gid},
+    ).get_json()["id"]
+
+    res = client.delete(f"/dashboard/api/bots/{aid}")
+    assert res.status_code == 200
+    assert Account.query.get(aid) is None
+
+    res = client.delete(f"/dashboard/api/groups/{gid}")
+    assert res.status_code == 200
+    assert Group.query.get(gid) is None


### PR DESCRIPTION
## Summary
- allow deleting groups or bots via new API endpoints
- remove bots from scheduler when deleted
- expose delete actions in dashboard UI
- document new feature
- test group and bot deletion

## Testing
- `PYTHONPATH=. pytest -q` *(fails: RuntimeError from scheduler after interpreter shutdown, but tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_6882c8aca5e483219e88fe3a13499409