### PR TITLE
Add group/bot management controls

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -113,7 +113,11 @@ async function loadGroups() {
   groups.forEach(g => {
     const li = document.createElement('li');
     li.className = 'mb-1';
-    li.innerHTML = `<div class="font-semibold">${g.name} (${g.target})</div>`;
+    li.innerHTML =
+      `<div class="flex justify-between items-center">` +
+      `<span class="font-semibold">${g.name} (${g.target})</span>` +
+      `<button onclick="deleteGroup(${g.id})" class="text-red-600 text-xs underline">Delete</button>` +
+      `</div>`;
     if (g.bots && g.bots.length) {
       const ul = document.createElement('ul');
       ul.className = 'pl-4 list-disc';
@@ -175,6 +179,7 @@ async function loadBots() {
       `<td class="border px-2 space-x-1">` +
         `<button onclick="startBot(${b.id})" class="bg-green-600 text-white px-2 py-1 text-xs rounded">Start</button>` +
         `<button onclick="stopBot(${b.id})" class="bg-red-600 text-white px-2 py-1 text-xs rounded">Stop</button>` +
+        `<button onclick="deleteBot(${b.id})" class="bg-gray-600 text-white px-2 py-1 text-xs rounded">Delete</button>` +
         `<button onclick="openCmd(${b.id})" class="bg-blue-500 text-white px-2 py-1 text-xs rounded">Cmd</button>` +
         `<button onclick="fetchLogs(${b.id})" class="underline text-xs">Logs</button>` +
       `</td>`;
@@ -212,6 +217,24 @@ async function stopBot(id) {
   const res = await api(`/dashboard/api/bots/${id}/stop`, {method: 'POST'});
   if (res && res.stopped) showToast('Bot stopped');
   loadBots();
+}
+
+async function deleteBot(id) {
+  if (!confirm('Delete this bot?')) return;
+  const res = await api(`/dashboard/api/bots/${id}`, {method: 'DELETE'});
+  if (res && res.deleted) showToast('Bot deleted');
+  loadBots();
+  loadGroups();
+  loadAccounts();
+}
+
+async function deleteGroup(id) {
+  if (!confirm('Delete this group?')) return;
+  const res = await api(`/dashboard/api/groups/${id}`, {method: 'DELETE'});
+  if (res && res.deleted) showToast('Group deleted');
+  loadGroups();
+  loadBots();
+  loadAccounts();
 }
 
 async function fetchLogs(id) {

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -78,8 +78,14 @@ class GroupResource(Resource):
     @jwt_required(optional=True)
     def get(self):
         search = (request.args.get("search") or "").strip()
-        page = int(request.args.get("page") or 1)
-        per_page = int(request.args.get("per_page") or 50)
+        try:
+            page = int(request.args.get("page") or 1)
+        except ValueError:
+            page = 1
+        try:
+            per_page = int(request.args.get("per_page") or 50)
+        except ValueError:
+            per_page = 50
         if not search and page == 1 and per_page == 50:
             cached = cache.get("groups")
             if cached is not None:
@@ -170,8 +176,14 @@ class AccountResource(Resource):
     @jwt_required(optional=True)
     def get(self):
         search = (request.args.get("search") or "").strip()
-        page = int(request.args.get("page") or 1)
-        per_page = int(request.args.get("per_page") or 50)
+        try:
+            page = int(request.args.get("page") or 1)
+        except ValueError:
+            page = 1
+        try:
+            per_page = int(request.args.get("per_page") or 50)
+        except ValueError:
+            per_page = 50
         query = Account.query
         if search:
             query = query.filter(Account.username.ilike(f"%{search}%"))
@@ -226,8 +238,14 @@ class BotListResource(Resource):
     @jwt_required(optional=True)
     def get(self):
         search = (request.args.get("search") or "").strip()
-        page = int(request.args.get("page") or 1)
-        per_page = int(request.args.get("per_page") or 50)
+        try:
+            page = int(request.args.get("page") or 1)
+        except ValueError:
+            page = 1
+        try:
+            per_page = int(request.args.get("per_page") or 50)
+        except ValueError:
+            per_page = 50
         query = Account.query
         if search:
             query = query.filter(Account.username.ilike(f"%{search}%"))

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -252,9 +252,8 @@ class BotListResource(Resource):
         pagination = query.paginate(page=page, per_page=per_page, error_out=False)
         bots = []
         for acc in pagination.items:
-            status = (
-                "online" if (Path("logs") / f"bot_{acc.id}.log").exists() else "offline"
-            )
+            proc = scheduler.processes.get(acc.id)
+            status = "online" if proc and proc.poll() is None else "offline"
             bots.append(
                 {
                     "id": acc.id,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,3 +109,23 @@ def test_bot_start_stop(client, tmp_path):
 
     res = client.post(f"/dashboard/api/bots/{aid}/stop")
     assert res.status_code == 200
+
+
+def test_delete_group_and_bot(client):
+    gid = client.post(
+        "/dashboard/api/groups", json={"name": "dg", "target": "t"}
+    ).get_json()["id"]
+    aid = client.post(
+        "/dashboard/api/accounts",
+        json={"username": "delbot", "password": "p", "group_id": gid},
+    ).get_json()["id"]
+
+    res = client.delete(f"/dashboard/api/bots/{aid}")
+    assert res.status_code == 200
+    assert res.get_json()["deleted"]
+    assert all(b["id"] != aid for b in client.get("/dashboard/api/bots").get_json()["items"])
+
+    res = client.delete(f"/dashboard/api/groups/{gid}")
+    assert res.status_code == 200
+    assert res.get_json()["deleted"]
+    assert all(g["id"] != gid for g in client.get("/dashboard/api/groups").get_json()["items"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -129,3 +129,16 @@ def test_delete_group_and_bot(client):
     assert res.status_code == 200
     assert res.get_json()["deleted"]
     assert all(g["id"] != gid for g in client.get("/dashboard/api/groups").get_json()["items"])
+
+
+def test_invalid_pagination_defaults(client):
+    res = client.get("/dashboard/api/groups?page=a&per_page=x")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert "items" in data and "total" in data
+
+    res = client.get("/dashboard/api/accounts?page=a")
+    assert res.status_code == 200
+
+    res = client.get("/dashboard/api/bots?per_page=b")
+    assert res.status_code == 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -142,3 +142,18 @@ def test_invalid_pagination_defaults(client):
 
     res = client.get("/dashboard/api/bots?per_page=b")
     assert res.status_code == 200
+
+
+def test_bots_list_shows_created_bot(client):
+    gid = client.post(
+        "/dashboard/api/groups", json={"name": "lb", "target": "t"}
+    ).get_json()["id"]
+    aid = client.post(
+        "/dashboard/api/accounts",
+        json={"username": "lbot", "password": "p", "group_id": gid},
+    ).get_json()["id"]
+
+    res = client.get("/dashboard/api/bots")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert any(b["id"] == aid for b in data["items"]) and "total" in data


### PR DESCRIPTION
## Summary
- implement DELETE endpoints for groups and bots
- expose bot and group delete controls in dashboard UI
- include new JS helpers for deleting bots and groups
- test delete endpoints

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883750b163483218543cf6824ab4324