### PR TITLE
Fix bot start duplication

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -282,6 +282,10 @@ class BotStart(Resource):
             "--token",
             Account.query.get(bot_id).password,
         ]
+        existing = scheduler.processes.get(bot_id)
+        if existing and existing.poll() is None:
+            return {"error": "bot already running", "pid": existing.pid}, 400
+
         proc = subprocess.Popen(cmd)
         scheduler.processes[bot_id] = proc
         scheduler.running_gauge.inc()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,6 +104,11 @@ def test_bot_start_stop(client, tmp_path):
     assert res.status_code == 200
     assert "pid" in res.get_json()
 
+    # starting again should return an error
+    res2 = client.post(f"/dashboard/api/bots/{aid}/start")
+    assert res2.status_code == 400
+    assert res2.get_json()["error"] == "bot already running"
+
     res = client.get(f"/dashboard/api/bots/{aid}/status")
     assert res.status_code == 200
 


### PR DESCRIPTION
## Summary
- avoid starting a bot if the process already exists
- test double start scenario

## Testing
- `PYTHONPATH=. pytest tests/test_api.py::test_bot_start_stop -vv`

------
https://chatgpt.com/codex/tasks/task_e_68838faf35608321afb668fe108fb3b9