### PR TITLE
Finalize KickBot manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # betterkickbot
 
-Utility scripts are located in the `scripts` folder. Run `python scripts/repair_db.py`
-to rebuild the local `bots.db` from `data.json`.
+Utility scripts are located in the `scripts` folder. Run `python scripts/repair_db.py` to rebuild the local `bots.db` from `data.json`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # betterkickbot
+
+Utility scripts are located in the `scripts` folder. Run `python scripts/repair_db.py`
+to rebuild the local `bots.db` from `data.json`.

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -24,13 +24,13 @@ function showToast(msg, ok = true) {
   setTimeout(() => toastBox.classList.add('hidden'), 3000);
 }
 
-async function checkRedis() {
+async function loadStatus() {
   const res = await fetch('/dashboard/api/status').catch(() => null);
   if (!res || !res.ok) return;
   const data = await res.json();
-  if (data.redis_online) redisBanner.classList.add('hidden');
+  if (data.redis) redisBanner.classList.add('hidden');
   else redisBanner.classList.remove('hidden');
-  if (data.worker_online) workerBanner.classList.add('hidden');
+  if (data.workers) workerBanner.classList.add('hidden');
   else workerBanner.classList.remove('hidden');
 }
 
@@ -387,9 +387,9 @@ const socket = io();
 ['bot_started','bot_stopped','bot_error','status'].forEach(evt => {
   socket.on(evt, () => { loadBots(); refreshStats(); });
 });
-socket.on('redis_status', () => checkRedis());
+socket.on('redis_status', () => loadStatus());
 socket.on('sync_event', syncPull);
-socket.on('connect', () => { syncPull(); syncPush(); checkRedis(); });
+socket.on('connect', () => { syncPull(); syncPush(); loadStatus(); });
 
 window.addEventListener('load', () => {
   loadGroups();
@@ -398,7 +398,7 @@ window.addEventListener('load', () => {
   refreshStats();
   syncPull();
   syncPush();
-  checkRedis();
-  setInterval(checkRedis, 5000);
+  loadStatus();
+  setInterval(loadStatus, 5000);
   if (!navigator.onLine) document.getElementById('offlineBanner').classList.remove('hidden');
 });

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -249,6 +249,16 @@ async function deleteGroup(id) {
   loadBots();
 }
 
+async function repairDb() {
+  const res = await api('/dashboard/api/repairdb', {method: 'POST'});
+  if (res && res.status === 'ok') {
+    showToast('Database rebuilt');
+    loadGroups();
+    loadAccounts();
+    loadBots();
+  }
+}
+
 async function fetchLogs(id) {
   if (logTimer) clearInterval(logTimer);
   async function load() {
@@ -265,6 +275,8 @@ async function fetchLogs(id) {
 
 document.getElementById('addGroupBtn').addEventListener('click', () => openModal('groupModal'));
 document.getElementById('addAccountBtn').addEventListener('click', () => openModal('accountModal'));
+const repairBtn = document.getElementById('repairDbBtn');
+if (repairBtn) repairBtn.addEventListener('click', repairDb);
 let groupTimer, accountTimer, botTimer;
 document.getElementById('groupSearch').addEventListener('input', () => {
   clearTimeout(groupTimer);

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -158,7 +158,7 @@ async function loadBots() {
   if (!data) return;
   const bots = data.items || [];
   const table = document.getElementById('botTable');
-  table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group</th><th>Status</th><th>Actions</th></tr>';
+  table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group ID</th><th>Status</th><th>Actions</th></tr>';
   if (!bots.length) {
     const row = document.createElement('tr');
     row.innerHTML = '<td class="border px-2 text-center" colspan="5">No bots created yet</td>';
@@ -173,7 +173,7 @@ async function loadBots() {
     row.innerHTML =
       `<td class="border px-2">${b.id}</td>` +
       `<td class="border px-2">${b.username}</td>` +
-      `<td class="border px-2">${b.group}</td>` +
+      `<td class="border px-2">${b.group_id}</td>` +
       `<td class="border px-2 text-center">${badge}</td>` +
       `<td class="border px-2 space-x-1">` +
         `<button onclick="startBot(${b.id})" class="bg-green-600 text-white px-2 py-1 text-xs rounded">Start</button>` +

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -135,7 +135,7 @@ async function loadAccounts() {
   const url = q.length > 1 ? '/dashboard/api/accounts?search=' + encodeURIComponent(q) : '/dashboard/api/accounts';
   const data = await api(url);
   if (!data) return;
-  const accs = data.items || data;
+  const accs = data.items || [];
   const table = document.getElementById('accountTable');
   table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group</th></tr>';
   if (!accs.length) {

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -158,7 +158,7 @@ async function loadBots() {
   if (!data) return;
   const bots = data.items || [];
   const table = document.getElementById('botTable');
-  table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group ID</th><th>Status</th><th>Actions</th></tr>';
+  table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group</th><th>Status</th><th>Actions</th></tr>';
   if (!bots.length) {
     const row = document.createElement('tr');
     row.innerHTML = '<td class="border px-2 text-center" colspan="5">No bots created yet</td>';
@@ -173,7 +173,7 @@ async function loadBots() {
     row.innerHTML =
       `<td class="border px-2">${b.id}</td>` +
       `<td class="border px-2">${b.username}</td>` +
-      `<td class="border px-2">${b.group_id}</td>` +
+      `<td class="border px-2">${b.group} (#${b.group_id})</td>` +
       `<td class="border px-2 text-center">${badge}</td>` +
       `<td class="border px-2 space-x-1">` +
         `<button onclick="startBot(${b.id})" class="bg-green-600 text-white px-2 py-1 text-xs rounded">Start</button>` +

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -29,6 +29,7 @@
   </div>
   <div id="offlineBanner" class="hidden bg-red-200 p-2 mb-2" role="status" aria-live="polite">Offline mode</div>
   <div id="redisBanner" class="hidden bg-yellow-200 p-2 mb-2" role="status" aria-live="polite">Redis offline</div>
+  <div id="workerBanner" class="hidden bg-yellow-200 p-2 mb-2" role="status" aria-live="polite">Scheduler stopped</div>
   <div id="toast" class="fixed top-4 right-4 bg-green-500 text-white px-3 py-2 rounded shadow hidden"></div>
   {% block content %}{% endblock %}
   <script>
@@ -52,6 +53,10 @@
   window.addEventListener('online', () => document.getElementById('offlineBanner').classList.add('hidden'));
   function updateRedis(status) {
     const b = document.getElementById('redisBanner');
+    if (status) b.classList.add('hidden'); else b.classList.remove('hidden');
+  }
+  function updateWorker(status) {
+    const b = document.getElementById('workerBanner');
     if (status) b.classList.add('hidden'); else b.classList.remove('hidden');
   }
   </script>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -10,7 +10,7 @@
         <button id="addGroupBtn" class="bg-green-600 text-white px-2 py-1 text-sm rounded">Add</button>
       </div>
       <input id="groupSearch" class="border rounded w-full mb-2 p-1" placeholder="Search groups">
-      <ul id="groupList" class="space-y-1 text-sm"></ul>
+      <table id="groupTable" class="w-full text-sm border-collapse"></table>
     </div>
   </section>
   <main class="md:col-span-3 space-y-4" id="mainArea">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -7,7 +7,10 @@
     <div class="bg-white rounded shadow p-4">
       <div class="flex justify-between items-center mb-2">
         <h2 class="font-bold text-lg">Groups</h2>
-        <button id="addGroupBtn" class="bg-green-600 text-white px-2 py-1 text-sm rounded">Add</button>
+        <div class="space-x-1">
+          <button id="addGroupBtn" class="bg-green-600 text-white px-2 py-1 text-sm rounded">Add</button>
+          <button id="repairDbBtn" class="bg-red-600 text-white px-2 py-1 text-sm rounded">Repair DB</button>
+        </div>
       </div>
       <input id="groupSearch" class="border rounded w-full mb-2 p-1" placeholder="Search groups">
       <table id="groupTable" class="w-full text-sm border-collapse"></table>

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -131,8 +131,9 @@ def create_app(config: Optional[dict] = None) -> Flask:
         sched.start()
         import atexit
         from . import scheduler as backend_scheduler
-        backend_scheduler.APP = app
         atexit.register(backend_scheduler.shutdown)
+    from . import scheduler as backend_scheduler
+    backend_scheduler.APP = app
 
     @app.before_request
     def log_request() -> None:

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -107,7 +107,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
                 fb = Path(app.config["SYNC_FALLBACK_FILE"])
                 if fb.exists():
                     fb.unlink()
-                scheduler.queue.enqueue(process_unsent_events, socketio)
+                scheduler.enqueue_sync_job(socketio)
                 if not getattr(app, "redis_online", True):
                     logger.info("Redis connection restored")
                     socketio.emit("redis_status", {"online": True})

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -131,6 +131,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
         sched.start()
         import atexit
         from . import scheduler as backend_scheduler
+        backend_scheduler.APP = app
         atexit.register(backend_scheduler.shutdown)
 
     @app.before_request

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -44,7 +44,10 @@ def create_app(config: Optional[dict] = None) -> Flask:
         template_folder=str(base_dir.parent / "app" / "templates"),
     )
 
-    db_uri = os.getenv("DATABASE_URL") or f"sqlite:///{cfg.DB_PATH}"
+    if os.getenv("DATABASE_URL"):
+        db_uri = os.getenv("DATABASE_URL")
+    else:
+        db_uri = f"sqlite:///{Path(cfg.DB_PATH).resolve()}"
     app.config.update(
         {
             "SECRET_KEY": cfg.SECRET_KEY,

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -200,7 +200,7 @@ class AccountResource(Resource):
             {"id": a.id, "username": a.username, "group_id": a.group_id}
             for a in pagination.items
         ]
-        return {"items": accounts, "total": pagination.total}
+        return {"items": accounts, "total": pagination.total}, 200
 
     @role_required("operator", "admin")
     def post(self):
@@ -385,8 +385,8 @@ class Status(Resource):
     @jwt_required(optional=True)
     def get(self):
         return {
-            "redis_online": scheduler.redis_online,
-            "worker_online": sched.running,
+            "redis": scheduler.redis_online,
+            "workers": sched.running,
         }
 
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -20,6 +20,7 @@ from .models import db, Group, Account, GroupSchema, AccountSchema, SyncEvent
 from .utils import role_required
 from . import scheduler
 from .scheduler import sched, schedule_all, log_sync_event
+from scripts.repair_db import rebuild_db
 import bcrypt
 
 api_bp = Blueprint("api", __name__)
@@ -461,3 +462,11 @@ def metrics():
 
     data = generate_latest(registry)
     return Response(data, mimetype="text/plain")
+
+
+@ns.route("/repairdb", methods=["POST"], endpoint="repair_db")
+class RepairDB(Resource):
+    @role_required("admin")
+    def post(self):
+        rebuild_db(current_app)
+        return {"status": "ok"}

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -261,6 +261,7 @@ class BotListResource(Resource):
                 {
                     "id": acc.id,
                     "username": acc.username,
+                    "group_id": acc.group_id,
                     "group": group.name if group else "",
                     "status": status,
                 }

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -136,6 +136,54 @@ class GroupResource(Resource):
         return {"id": group.id}, 201
 
 
+@ns.route("/groups/<int:group_id>", methods=["DELETE"], endpoint="group_delete")
+class GroupDelete(Resource):
+    @role_required("operator", "admin")
+    def delete(self, group_id: int):
+        group = Group.query.get(group_id)
+        if not group:
+            return {"error": "group not found"}, 404
+        for acc in group.accounts:
+            scheduler.stop_bot_process(acc.id)
+            scheduler.sched.remove_job(str(acc.id))
+            db.session.delete(acc)
+        db.session.delete(group)
+        db.session.commit()
+        current_app.extensions["socketio"].emit("group_deleted", {"id": group_id})
+        return {"deleted": True}
+
+
+@ns.route("/groups/<int:group_id>/start", methods=["POST"], endpoint="group_start")
+class GroupStart(Resource):
+    @role_required("operator", "admin")
+    def post(self, group_id: int):
+        group = Group.query.get(group_id)
+        if not group:
+            return {"error": "group not found"}, 404
+        started = 0
+        for acc in group.accounts:
+            proc = scheduler.start_bot_process(acc.id)
+            if proc:
+                started += 1
+                current_app.extensions["socketio"].emit("bot_started", {"id": acc.id})
+        return {"started": started}
+
+
+@ns.route("/groups/<int:group_id>/stop", methods=["POST"], endpoint="group_stop")
+class GroupStop(Resource):
+    @role_required("operator", "admin")
+    def post(self, group_id: int):
+        group = Group.query.get(group_id)
+        if not group:
+            return {"error": "group not found"}, 404
+        stopped = 0
+        for acc in group.accounts:
+            if scheduler.stop_bot_process(acc.id):
+                stopped += 1
+                current_app.extensions["socketio"].emit("bot_stopped", {"id": acc.id})
+        return {"stopped": stopped}
+
+
 @ns.route("/accounts", methods=["GET", "POST"], endpoint="accounts")
 class AccountResource(Resource):
     @jwt_required(optional=True)
@@ -263,43 +311,39 @@ class SchedulerStart(Resource):
 class BotStart(Resource):
     @role_required("operator", "admin")
     def post(self, bot_id: int):
-        group = Group.query.join(Account).filter(Account.id == bot_id).first()
-        if not group:
+        proc = scheduler.processes.get(bot_id)
+        if proc and proc.poll() is None:
+            scheduler.stop_bot_process(bot_id)
+        new_proc = scheduler.start_bot_process(bot_id)
+        if not new_proc:
             return {"error": "bot not found"}, 404
-        msg_path = Path(Account.query.get(bot_id).messages_file or "")
-        msg = "Hello from KickBot"
-        if msg_path.is_file():
-            msg = msg_path.read_text().splitlines()[0]
-        cmd = [
-            "python",
-            str(Path(__file__).resolve().parent.parent / "scripts" / "run_bot.py"),
-            "--channel",
-            group.target,
-            "--message",
-            msg,
-            "--interval",
-            str(group.interval),
-            "--token",
-            Account.query.get(bot_id).password,
-        ]
-        proc = subprocess.Popen(cmd)
-        scheduler.processes[bot_id] = proc
-        scheduler.running_gauge.inc()
         current_app.extensions["socketio"].emit("bot_started", {"id": bot_id})
-        return {"pid": proc.pid}
+        return {"pid": new_proc.pid}
 
 
 @ns.route("/bots/<int:bot_id>/stop", methods=["POST"], endpoint="bot_stop")
 class BotStop(Resource):
     @role_required("operator", "admin")
     def post(self, bot_id: int):
-        proc = scheduler.processes.get(bot_id)
-        if proc and proc.poll() is None:
-            proc.terminate()
-            scheduler.running_gauge.dec()
+        stopped = scheduler.stop_bot_process(bot_id)
+        if stopped:
             current_app.extensions["socketio"].emit("bot_stopped", {"id": bot_id})
-            return {"stopped": True}
-        return {"stopped": False}
+        return {"stopped": stopped}
+
+
+@ns.route("/bots/<int:bot_id>", methods=["DELETE"], endpoint="bot_delete")
+class BotDelete(Resource):
+    @role_required("operator", "admin")
+    def delete(self, bot_id: int):
+        acc = Account.query.get(bot_id)
+        if not acc:
+            return {"error": "bot not found"}, 404
+        scheduler.stop_bot_process(bot_id)
+        scheduler.sched.remove_job(str(bot_id))
+        db.session.delete(acc)
+        db.session.commit()
+        current_app.extensions["socketio"].emit("bot_deleted", {"id": bot_id})
+        return {"deleted": True}
 
 
 @ns.route("/bots/<int:bot_id>/status", methods=["GET"], endpoint="bot_status")
@@ -331,6 +375,16 @@ class Stats(Resource):
         return {
             "runs": int(scheduler.runs_counter._value.get()),
             "errors": int(scheduler.errors_counter._value.get()),
+        }
+
+
+@ns.route("/status", methods=["GET"], endpoint="status")
+class Status(Resource):
+    @jwt_required(optional=True)
+    def get(self):
+        return {
+            "redis_online": scheduler.redis_online,
+            "worker_online": sched.running,
         }
 
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -190,6 +190,14 @@ def enqueue_send_job(bot_id: int, socketio: SocketIO) -> None:
     asyncio.run_coroutine_threadsafe(send_job(bot_id, socketio), aio_loop)
 
 
+def enqueue_sync_job(socketio: SocketIO) -> None:
+    """Enqueue the sync task or run inline if Redis is unavailable."""
+    if queue:
+        queue.enqueue(process_unsent_events, socketio)
+    else:
+        process_unsent_events(socketio)
+
+
 def schedule_all(socketio: SocketIO) -> None:
     sched.remove_all_jobs()
     for acc in Account.query.all():

--- a/scripts/repair_db.py
+++ b/scripts/repair_db.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Repair or rebuild the local bots.db from data.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend import create_app
+from backend.models import db, Group, Account
+
+DATA_FILE = Path(__file__).resolve().parent.parent / "data.json"
+DB_PATH = Path("bots.db")
+
+
+def load_data() -> dict:
+    if DATA_FILE.is_file():
+        return json.loads(DATA_FILE.read_text())
+    return {"accounts": [], "groups": []}
+
+
+def rebuild_db() -> None:
+    app = create_app()
+    data = load_data()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        # map account id -> group id from group definitions
+        id_to_gid: dict[int, int] = {}
+        for grp in data.get("groups", []):
+            group = Group(
+                name=grp.get("name"),
+                target=grp.get("target", "unknown"),
+                interval=grp.get("interval", 600),
+            )
+            db.session.add(group)
+            db.session.flush()
+            for aid in grp.get("accounts", []):
+                id_to_gid[aid] = group.id
+
+        for acc in data.get("accounts", []):
+            account = Account(
+                id=acc.get("id"),
+                username=acc.get("email"),
+                password=acc.get("password"),
+                proxy=acc.get("proxy"),
+                group_id=id_to_gid.get(acc.get("id")),
+            )
+            db.session.add(account)
+        db.session.commit()
+    print("Database rebuilt at", DB_PATH)
+
+
+def main() -> None:
+    rebuild_db()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repair_db.py
+++ b/scripts/repair_db.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from backend import create_app
+from flask import Flask
 from backend.models import db, Group, Account
 
 DATA_FILE = Path(__file__).resolve().parent.parent / "data.json"
@@ -19,8 +19,10 @@ def load_data() -> dict:
     return {"accounts": [], "groups": []}
 
 
-def rebuild_db() -> None:
-    app = create_app()
+def rebuild_db(app: Flask | None = None) -> None:
+    if app is None:
+        from backend import create_app
+        app = create_app()
     data = load_data()
     with app.app_context():
         db.drop_all()


### PR DESCRIPTION
## Summary
- add group management endpoints and health check
- clean subprocesses and remove lambdas from scheduler
- expose worker/redis status on the dashboard and show banners
- allow start/stop/delete from UI
- restrict CSP to required CDNs

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a24add00832184357ff5e7752bb3